### PR TITLE
fix(webhook): prevent premature garbage collection of background tasks

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -101,6 +101,9 @@ This document captures the full context required to maintain, extend, or operate
    - Each event triggers fetching, logging, and optional persistence.
    - Returns aggregated message summarizing processed events.
 
+- Background processing tasks keep strong references via `_BACKGROUND_TASKS`
+  to avoid premature garbage collection when scheduled with `asyncio.create_task`.
+
 4. **Error Handling**
    - Invalid JSON → `400` with detail message.
    - Invalid signature → `401`.


### PR DESCRIPTION
Previously, background tasks scheduled with `asyncio.create_task` in the Notion webhook handler could be prematurely garbage collected if no strong references were held, leading to incomplete or lost processing of incoming Notion events. This could result in missed entity fetches, failed persistence, or inconsistent webhook responses, especially under high load or when the event loop was busy.

This commit introduces a module-level `_BACKGROUND_TASKS` set in `app/routers/webhooks.py` to hold strong references to all in-flight background tasks. Each new task is added to this set upon creation, and a done callback is registered to remove the task from the set once it completes. This ensures that all background processing is reliably executed and not interrupted by Python's garbage collector.

The AGENT.md documentation is updated to describe this mechanism, clarifying the rationale and implementation for future maintainers.

This change improves the reliability and correctness of webhook event processing, especially in asynchronous and production environments.