### PR TITLE
feat: persist and expose Notion breadcrumbs in content snapshots

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -36,7 +36,7 @@ This document captures the full context required to maintain, extend, or operate
 
 - **Adapters (`app/adapters/`)**
   - `content.py` implements `ContentStoreAdapter` using `pg8000` for pure-Python PostgreSQL access.
-    - Lazily ensures `notion_contents` table exists with columns: `id`, `entity_type`, `title`, `url`, `markdown`, `updated_at`.
+    - Lazily ensures `notion_contents` table exists with columns: `id`, `entity_type`, `title`, `url`, `markdown`, `breadcrumbs`, `updated_at`.
     - Upserts snapshots with `INSERT ... ON CONFLICT`.
   - `__init__.py` exposes `get_content_adapter()` as a singleton factory.
   - `postgres.py` (legacy) remains for future use but is currently unused.
@@ -58,9 +58,10 @@ This document captures the full context required to maintain, extend, or operate
 | `title`      | TEXT      | Extracted title (best effort)              |
 | `url`        | TEXT      | Notion URL (direct or synthesized)         |
 | `markdown`   | TEXT      | Markdown representation of the entity      |
+| `breadcrumbs`| TEXT      | JSON text with array of breadcrumb nodes   |
 | `updated_at` | TIMESTAMP | Automatically refreshed on every upsert    |
 
-> The adapter will create the table (and add the `title` column if missing) every time the app starts and detects configured DB credentials.
+> The adapter will create the table (and add the `title` and `breadcrumbs` columns if missing) every time the app starts and detects configured DB credentials.
 
 ---
 

--- a/tests/services/test_notion.py
+++ b/tests/services/test_notion.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import json
 
 from fastapi import Request
 
@@ -118,13 +119,17 @@ class TestNotionModule:
         """Ensure schema setup is invoked when credentials exist."""
         mock_adapter = mocker.Mock()
         mock_adapter.ensure_schema = mocker.AsyncMock()
-        mocker.patch("app.services.notion.get_content_adapter", return_value=mock_adapter)
+        mocker.patch(
+            "app.services.notion.get_content_adapter", return_value=mock_adapter
+        )
 
         await notion.ensure_content_storage()
 
         mock_adapter.ensure_schema.assert_awaited_once()
 
-    async def test_ensure_content_storage_skips_without_credentials(self, monkeypatch, mocker):
+    async def test_ensure_content_storage_skips_without_credentials(
+        self, monkeypatch, mocker
+    ):
         """Skip schema setup when credentials are missing."""
         original_host = settings.DB_HOST
         monkeypatch.setattr(settings, "DB_HOST", "")
@@ -135,3 +140,105 @@ class TestNotionModule:
             get_adapter.assert_not_called()
         finally:
             monkeypatch.setattr(settings, "DB_HOST", original_host)
+
+
+class TestBreadcrumbs:
+    async def test_fetch_entity_data_includes_breadcrumbs(self, mocker, mock_settings):
+        """Ensure fetch_entity_data returns breadcrumbs chain from root to entity."""
+
+        # Stub child blocks to avoid extra calls
+        mocker.patch(
+            "app.services.notion._fetch_block_children",
+            new=mocker.AsyncMock(return_value=[]),
+        )
+
+        # Map URLs to payloads
+        NOTION_API_URL = "https://api.notion.com/v1"
+
+        def payload_for(url: str):
+            if url == f"{NOTION_API_URL}/pages/page-1":
+                return {
+                    "id": "page-1",
+                    "parent": {"page_id": "page-0"},
+                    "properties": {
+                        "title": {"type": "title", "title": [{"plain_text": "Child"}]}
+                    },
+                    "url": "https://www.notion.so/child",
+                }
+            if url == f"{NOTION_API_URL}/pages/page-0":
+                return {
+                    "id": "page-0",
+                    "parent": {"database_id": "db-1"},
+                    "properties": {
+                        "title": {"type": "title", "title": [{"plain_text": "Parent"}]}
+                    },
+                    "url": "https://www.notion.so/parent",
+                }
+            if url == f"{NOTION_API_URL}/databases/db-1":
+                return {
+                    "id": "db-1",
+                    "parent": {"workspace": True},
+                    "title": [{"plain_text": "RootDB"}],
+                    "url": "https://www.notion.so/db-1",
+                }
+            raise AssertionError(f"Unexpected URL requested: {url}")
+
+        class StubResponse:
+            def __init__(self, data):
+                self._data = data
+
+            def json(self):
+                return self._data
+
+        async def fake_request_with_retry(
+            method, url, *, headers=None, params=None, json_payload=None
+        ):
+            return StubResponse(payload_for(url))
+
+        mocker.patch(
+            "app.services.notion._request_with_retry", new=fake_request_with_retry
+        )
+
+        from app.services import notion
+
+        entity = await notion.fetch_entity_data(entity_id="page-1", entity_type="page")
+        assert entity is not None
+        assert "breadcrumbs" in entity
+        breadcrumbs = entity["breadcrumbs"]
+        assert [node["id"] for node in breadcrumbs] == ["db-1", "page-0", "page-1"]
+        assert [node["type"] for node in breadcrumbs] == ["database", "page", "page"]
+        assert [node["title"] for node in breadcrumbs] == ["RootDB", "Parent", "Child"]
+
+    async def test_save_entity_persists_breadcrumbs_json(self, mocker):
+        """Ensure save_entity serializes breadcrumbs and passes to adapter.upsert."""
+
+        from app.services import notion
+
+        mock_adapter = mocker.Mock()
+        mock_adapter.upsert = mocker.AsyncMock()
+        mocker.patch(
+            "app.services.notion.get_content_adapter", return_value=mock_adapter
+        )
+
+        entity_data = {
+            "markdown": "",
+            "url": "https://example/page-1",
+            "title": "Child",
+            "breadcrumbs": [
+                {
+                    "id": "db-1",
+                    "type": "database",
+                    "title": "RootDB",
+                    "url": "https://example/db-1",
+                }
+            ],
+        }
+
+        result = await notion.save_entity("page-1", "page", entity_data)
+        assert result is True
+        mock_adapter.upsert.assert_awaited_once()
+        args, _ = mock_adapter.upsert.call_args
+        # last positional argument is breadcrumbs_json
+        breadcrumbs_json = args[5]
+        assert isinstance(breadcrumbs_json, str)
+        assert json.loads(breadcrumbs_json) == entity_data["breadcrumbs"]

--- a/tests/services/test_notion.py
+++ b/tests/services/test_notion.py
@@ -180,9 +180,7 @@ class TestBreadcrumbs:
             },
         }
 
-        async def fake_request_with_retry(
-            method, url, **kwargs
-        ):
+        async def fake_request_with_retry(method, url, **kwargs):
             path = url.removeprefix(NOTION_API_URL)
             try:
                 return mocker.MagicMock(json=lambda: payloads[path])
@@ -197,8 +195,6 @@ class TestBreadcrumbs:
             "app.services.notion._request_with_retry", new=fake_request_with_retry
         )
 
-        from app.services import notion
-
         entity = await notion.fetch_entity_data(entity_id="page-1", entity_type="page")
         assert entity is not None
         assert "breadcrumbs" in entity
@@ -209,8 +205,6 @@ class TestBreadcrumbs:
 
     async def test_save_entity_persists_breadcrumbs_json(self, mocker):
         """Ensure save_entity serializes breadcrumbs and passes to adapter.upsert."""
-
-        from app.services import notion
 
         mock_adapter = mocker.Mock()
         mock_adapter.upsert = mocker.AsyncMock()


### PR DESCRIPTION
- Adds the `breadcrumbs` column to the `notion_contents` table to store the full breadcrumb (hierarchy) chain for each Notion entity, serialized as JSON.
- The content adapter now ensures the creation of the `breadcrumbs` column (in addition to `title`) when initializing the schema, supporting seamless schema evolution.
- The Notion entity fetch service (`fetch_entity_data`) always computes and includes breadcrumbs for both pages and databases, traversing the parent hierarchy as returned by the Notion API.
- Each persisted snapshot now includes the complete breadcrumbs chain, enabling downstream consumers to reconstruct the navigation path and hierarchical context for any entity.
- Agent documentation and specification updated to reflect the new field and behavior.
- Tests extended to ensure breadcrumbs are fetched, stored, and exposed correctly.
- Reference: [Notion API docs - Page object: parent](https://developers.notion.com/reference/page#parent-object) and [Database object: parent](https://developers.notion.com/reference/database#parent-object). Breadcrumb navigation is based on the `parent` structure returned by these endpoints.
- This enhancement improves traceability and allows consumers to reconstruct the full Notion hierarchy for any saved entity.

fixed: #2 